### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": "",
+  "repository": "grncdr/merge-stream",
   "author": "Stephen Sugden <me@stephensugden.com>",
   "license": "MIT"
 }


### PR DESCRIPTION
If we add the `repository` field in the form of `<repo_author>/<repo_name>`, it automatically fills up `homepage` and `bugs` field. See [the package.json](https://github.com/sindresorhus/pageres/blob/master/package.json) and [the repository page](https://www.npmjs.org/package/pageres) of [pageres](https://github.com/sindresorhus/pageres) as an example.
