### PR TITLE
Add isEmpty method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
- - 0.10
- - 0.12
+ - "0.10"
+ - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
  - 0.10
- - 0.11
+ - 0.12

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function (/*streams...*/) {
   output.setMaxListeners(0)
 
   output.add = add
+  output.isEmpty = isEmpty
 
   output.on('unpipe', remove)
 
@@ -26,6 +27,10 @@ module.exports = function (/*streams...*/) {
     source.once('end', remove.bind(null, source))
     source.pipe(output, {end: false})
     return this
+  }
+
+  function isEmpty () {
+    return sources.length == 0;
   }
 
   function remove (source) {

--- a/test.js
+++ b/test.js
@@ -60,6 +60,12 @@ test('array', function (combined) {
   range(-100)
 ]))
 
+test('isEmpty', function (combined) {
+  assert(combined.isEmpty());
+  combined.add(range(1));
+  assert(!combined.isEmpty());
+})
+
 function range (n) {
   var k = n > 0 ? -1 : 1
   return from.obj(function (_, next) {

--- a/test.js
+++ b/test.js
@@ -62,6 +62,7 @@ test('array', function (combined) {
 
 test('isEmpty', function (combined) {
   assert(combined.isEmpty());
+  combined.on('data', function (n) { assert.equal(0, n) });
   combined.add(range(1));
   assert(!combined.isEmpty());
 })


### PR DESCRIPTION
When a stream is "empty" (aka. no sources were added), it could not be returned to a gulp task, and i suppose this situation could come across somewhere else.

So, now, we can imagine a something like that:

    stream = require('merge-stream')();
    // Something like a loop to add some streams to the merge stream
    // stream.add(streamA);
    // stream.add(streamB);
    return stream.isEmpty() ? null : stream;