### PR TITLE
Switch from Streams2 to Streams3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var through = require('through2')
+var PassThrough = require('readable-stream/passthrough')
 
 module.exports = function (/*streams...*/) {
   var sources = []
-  var output  = through.obj()
+  var output  = new PassThrough({objectMode: true})
 
   output.setMaxListeners(0)
 

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "author": "Stephen Sugden <me@stephensugden.com>",
   "license": "MIT",
   "dependencies": {
-    "through2": "^0.6.1"
+    "readable-stream": "^2.0.1"
   },
   "devDependencies": {
-    "from2": "^1.2.0",
+    "from2": "^2.0.3",
     "istanbul": "^0.3.2"
   }
 }


### PR DESCRIPTION
The current latest version of merge-stream uses Streams2 via the [through2](https://github.com/rvagg/through2) module but Streams2 is an older implementation.

This PR replaces through2 v0.6 with [readable-stream](https://github.com/nodejs/readable-stream) v2.0.0 to switch to Streams3 which is a more popular stream implementation as it's used in the latest Node and io.js.
