### PR TITLE
Modernize js to es6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 coverage
 node_modules
-package-lock.json
+yarn.lock

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,12 +1,10 @@
 {
-  "globalstrict": true,
-  "node": true,
-  "proto": true,
-  "quotmark": "single",
-  "strict": true,
-  "trailing": true,
+  "esversion": 6,
+  "strict": "implied",
+  "eqeqeq": true,
+  "undef": true,
   "unused": true,
+  "node": true,
   "latedef": "nofunc",
   "asi": true
 }
-

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
   "esversion": 6,
-  "strict": "implied",
+  "strict": "global",
   "eqeqeq": true,
   "undef": true,
   "unused": true,

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Merge (interleave) a bunch of streams.
 ## Synopsis
 
 ```javascript
-var stream1 = new Stream();
-var stream2 = new Stream();
+const stream1 = new Stream();
+const stream2 = new Stream();
 
-var merged = mergeStream(stream1, stream2);
+const merged = mergeStream(stream1, stream2);
 
-var stream3 = new Stream();
+const stream3 = new Stream();
 merged.add(stream3);
 merged.isEmpty();
 //=> false
@@ -60,7 +60,7 @@ const htmlValidator = require('gulp-w3c-html-validator');
 const jsHint =        require('gulp-jshint');
 const mergeStream =   require('merge-stream');
 
-function lint() {
+const taskLint = () => {
   return mergeStream(
     gulp.src('src/*.html')
       .pipe(htmlValidator())
@@ -69,8 +69,8 @@ function lint() {
       .pipe(jsHint())
       .pipe(jsHint.reporter())
   );
-}
-gulp.task('lint', lint);
+};
+gulp.task('lint', taskLint);
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,10 +1,30 @@
-'use strict';
+// merge-stream
 
 const { PassThrough } = require('stream');
 
 module.exports = function (/*streams...*/) {
-  var sources = []
-  var output  = new PassThrough({objectMode: true})
+  let sources = []
+  const output  = new PassThrough({objectMode: true})
+
+  const remove = (source) => {
+    sources = sources.filter(it => it !== source)
+    if (!sources.length && output.readable) { output.end() }
+  }
+
+  const add = (source) => {
+    if (Array.isArray(source)) {
+      source.forEach(add)
+      return global
+    }
+
+    sources.push(source);
+    source.once('end', remove.bind(null, source))
+    source.once('error', output.emit.bind(output, 'error'))
+    source.pipe(output, {end: false})
+    return global
+  }
+
+  const isEmpty = () => sources.length === 0
 
   output.setMaxListeners(0)
 
@@ -16,26 +36,4 @@ module.exports = function (/*streams...*/) {
   Array.prototype.slice.call(arguments).forEach(add)
 
   return output
-
-  function add (source) {
-    if (Array.isArray(source)) {
-      source.forEach(add)
-      return this
-    }
-
-    sources.push(source);
-    source.once('end', remove.bind(null, source))
-    source.once('error', output.emit.bind(output, 'error'))
-    source.pipe(output, {end: false})
-    return this
-  }
-
-  function isEmpty () {
-    return sources.length == 0;
-  }
-
-  function remove (source) {
-    sources = sources.filter(function (it) { return it !== source })
-    if (!sources.length && output.readable) { output.end() }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "index.js"
   ],
   "scripts": {
+    "pretest": "jshint *.js",
     "test": "istanbul cover test.js && istanbul check-cover --statements 100 --branches 100"
   },
   "repository": "grncdr/merge-stream",
@@ -14,6 +15,7 @@
   "dependencies": {},
   "devDependencies": {
     "from2": "^2.0.3",
-    "istanbul": "^0.4.5"
+    "istanbul": "^0.4.5",
+    "jshint": "~2.10.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,90 +1,101 @@
-'use strict';
+// merge-stream
 
-var assert = require('assert')
-var from = require('from2')
+const assert = require('assert')
+const from = require('from2')
 
-var merge = require('./')
+const merge = require('./')
 
-function test (name, fn, c) {
-  var combined = c || merge();
-  var to = after(1000, process.emit.bind(process), 'error', new Error('Timed out: ' + name))
-  combined.on('end', function () {
+const range = (n) => {
+  const k = n > 0 ? -1 : 1
+  return from.obj((_, next) => {
+    setTimeout(() => {
+      next(null, n === 0 ? null : n += k)
+    }, Math.round(6 + Math.round(Math.random() * 6)));
+  })
+}
+
+const after = (ms, fn, a, b, c) => setTimeout(fn, ms, a, b, c)
+
+const test = (name, fn, c) => {
+  let combined = c || merge();
+  const to = after(1500, process.emit.bind(process), 'error', new Error('Timed out: ' + name))
+  combined.on('end', () => {
     clearTimeout(to)
   });
   fn(combined);
 }
 
-test('smoke', function (combined) {
+test('smoke', (combined) => {
 
-  function addSource (i) {
+  const addSource = (i) => {
     if (i === 38) return;
     combined.add(range(i))
     after(6, addSource, i + 1)
   }
 
-  var total = 0
+  let total = 0
 
-  combined.on('data', function (i) { total += i })
-  combined.on('end', function () { assert.equal(666, total) })
+  combined.on('data', (i) => total += i)
+  combined.on('end', () => assert.equal(666, total))
 
   addSource(-36)
 })
 
-test('pause/resume', function (combined) {
+test('pause/resume', (combined) => {
   combined.add(range(100))
   combined.add(range(-100))
-  var counter = 0;
-  combined.on('data', function () { counter++ })
+  let counter = 0;
+  combined.on('data', () => counter++)
 
-  after(20, function () {
+  after(20, () => {
     combined.pause()
     assert(counter < 200)
-    var pauseCount = counter;
+    const pauseCount = counter;
 
-    after(50, function () {
+    after(50, () => {
       assert.equal(pauseCount, counter);
       combined.resume();
     });
 
   });
 
-  combined.on('end', function () { assert.equal(counter, 200) })
+  combined.on('end', () => assert.equal(counter, 200))
 })
 
-test('array', function (combined) {
-  var counter = 0;
-  combined.on('data', function () { counter++ })
-  combined.on('end', function () { assert.equal(counter, 200) })
+test('array', (combined) => {
+  let counter = 0;
+  combined.on('data', () => counter++)
+  combined.on('end', () => assert.equal(counter, 200))
 }, merge([
   range(100),
   range(-100)
 ]))
 
-test('isEmpty', function (combined) {
+test('isEmpty', (combined) => {
   assert(combined.isEmpty());
-  combined.on('data', function (n) { assert.equal(0, n) });
+  combined.on('data', (n) => assert.equal(0, n));
   combined.add(range(1));
   assert(!combined.isEmpty());
 })
 
-test('propagates errors', function (combined) {
-  var ERROR_MESSAGE = 'TEST: INTERNAL STREAM ERROR';
-  var streamToError = range(100);
-  var streamJustFine = range(-100);
-  var errorCounter = 0;
+test('propagates errors', (combined) => {
+  const ERROR_MESSAGE = 'TEST: INTERNAL STREAM ERROR';
+  const streamToError = range(100);
+  const streamJustFine = range(-100);
+  let errorCounter = 0;
 
   combined.add(streamToError);
   combined.add(streamJustFine);
-  combined.on('error', function(err) {
+  combined.on('error', (err) => {
     assert.equal(err.message, ERROR_MESSAGE);
     errorCounter++;
   })
 
-  after(50, function () {
+  after(50, () => {
     assert.equal(errorCounter, 0);
     streamToError.emit('error', new Error(ERROR_MESSAGE));
 
-    after(1, function () {
+    after(1, () => {
       assert.equal(errorCounter, 1);
       // End the stream manually to end the test
       combined.emit('end');
@@ -92,14 +103,3 @@ test('propagates errors', function (combined) {
 
   });
 })
-
-function range (n) {
-  var k = n > 0 ? -1 : 1
-  return from.obj(function (_, next) {
-    setTimeout(function () {
-      next(null, n === 0 ? null : n += k)
-    }, Math.round(6 + Math.round(Math.random() * 6)));
-  })
-}
-
-function after (ms, fn, a, b, c) { return setTimeout(fn, ms, a, b, c) }

--- a/test.js
+++ b/test.js
@@ -1,33 +1,22 @@
-// merge-stream
+'use strict';
 
 const assert = require('assert')
 const from = require('from2')
 
 const merge = require('./')
 
-const range = (n) => {
-  const k = n > 0 ? -1 : 1
-  return from.obj((_, next) => {
-    setTimeout(() => {
-      next(null, n === 0 ? null : n += k)
-    }, Math.round(6 + Math.round(Math.random() * 6)));
-  })
-}
-
-const after = (ms, fn, a, b, c) => setTimeout(fn, ms, a, b, c)
-
-const test = (name, fn, c) => {
-  let combined = c || merge();
+function test (name, fn, c) {
+  const combined = c || merge();
   const to = after(1500, process.emit.bind(process), 'error', new Error('Timed out: ' + name))
-  combined.on('end', () => {
+  combined.on('end', function () {
     clearTimeout(to)
   });
   fn(combined);
 }
 
-test('smoke', (combined) => {
+test('smoke', function (combined) {
 
-  const addSource = (i) => {
+  function addSource (i) {
     if (i === 38) return;
     combined.add(range(i))
     after(6, addSource, i + 1)
@@ -35,50 +24,50 @@ test('smoke', (combined) => {
 
   let total = 0
 
-  combined.on('data', (i) => total += i)
-  combined.on('end', () => assert.equal(666, total))
+  combined.on('data', function (i) { total += i })
+  combined.on('end', function () { assert.equal(666, total) })
 
   addSource(-36)
 })
 
-test('pause/resume', (combined) => {
+test('pause/resume', function (combined) {
   combined.add(range(100))
   combined.add(range(-100))
   let counter = 0;
-  combined.on('data', () => counter++)
+  combined.on('data', function () { counter++ })
 
-  after(20, () => {
+  after(20, function () {
     combined.pause()
     assert(counter < 200)
     const pauseCount = counter;
 
-    after(50, () => {
+    after(50, function () {
       assert.equal(pauseCount, counter);
       combined.resume();
     });
 
   });
 
-  combined.on('end', () => assert.equal(counter, 200))
+  combined.on('end', function () { assert.equal(counter, 200) })
 })
 
-test('array', (combined) => {
+test('array', function (combined) {
   let counter = 0;
-  combined.on('data', () => counter++)
-  combined.on('end', () => assert.equal(counter, 200))
+  combined.on('data', function () { counter++ })
+  combined.on('end', function () { assert.equal(counter, 200) })
 }, merge([
   range(100),
   range(-100)
 ]))
 
-test('isEmpty', (combined) => {
+test('isEmpty', function (combined) {
   assert(combined.isEmpty());
-  combined.on('data', (n) => assert.equal(0, n));
+  combined.on('data', function (n) { assert.equal(0, n) });
   combined.add(range(1));
   assert(!combined.isEmpty());
 })
 
-test('propagates errors', (combined) => {
+test('propagates errors', function (combined) {
   const ERROR_MESSAGE = 'TEST: INTERNAL STREAM ERROR';
   const streamToError = range(100);
   const streamJustFine = range(-100);
@@ -86,16 +75,16 @@ test('propagates errors', (combined) => {
 
   combined.add(streamToError);
   combined.add(streamJustFine);
-  combined.on('error', (err) => {
+  combined.on('error', function(err) {
     assert.equal(err.message, ERROR_MESSAGE);
     errorCounter++;
   })
 
-  after(50, () => {
+  after(50, function () {
     assert.equal(errorCounter, 0);
     streamToError.emit('error', new Error(ERROR_MESSAGE));
 
-    after(1, () => {
+    after(1, function () {
       assert.equal(errorCounter, 1);
       // End the stream manually to end the test
       combined.emit('end');
@@ -103,3 +92,14 @@ test('propagates errors', (combined) => {
 
   });
 })
+
+function range (n) {
+  const k = n > 0 ? -1 : 1
+  return from.obj(function (_, next) {
+    setTimeout(function () {
+      next(null, n === 0 ? null : n += k)
+    }, Math.round(6 + Math.round(Math.random() * 6)));
+  })
+}
+
+function after (ms, fn, a, b, c) { return setTimeout(fn, ms, a, b, c) }


### PR DESCRIPTION
1. Set `strict` to `"implied"` (updated `this` to `global`)
2. `var` to `const` or `let`
3. functions to fat arrows (`=>`) and had to move definitions before usage
4. Bumped testing timeout from 1000 to 1500 to allow completion
5. Updated **.jshintrc** and added **npm** `pretest` script to do linting

This PR changes a lot of lines of code, but the changes are intended to be just syntactic updates.  There should be no functional differences at all.  The code should now look more modern but still behave exactly the same.  I attempted to follow the existing styles in the project (such as indentation and semicolon usage) as much as possible, but feel free to reformat any style I didn't get right.